### PR TITLE
Update Chinese.xml and Chinesetraditional.xml

### DIFF
--- a/Mods/BookOfOrigins_395a6fbb-f855-4cb0-97a9-6674bfd1799b/Localization/Chinese/Chinese.xml
+++ b/Mods/BookOfOrigins_395a6fbb-f855-4cb0-97a9-6674bfd1799b/Localization/Chinese/Chinese.xml
@@ -17,7 +17,7 @@
 	<content contentuid="h69bc41c7ga800g4d1fgb20bg23ba44d44b64" Source="BOO_BookOfOrigins_Dialog.lsj">矮人之血脉。 &lt;i&gt;(石化之触)&lt;/i&gt;</content>
 	<content contentuid="h59d3c53egb9e0g4fbcgb908ge936f1adbc54" Source="BOO_BookOfOrigins_Dialog.lsj">无法被束缚之人。 &lt;i&gt;(打破枷锁)&lt;/i&gt;</content>
 	<content contentuid="h0380055dg8534g46ecga09fgbe08c34aaff7" Source="BOOK_BOO_BookOfOrigins">一本神秘的书籍。 能阅读它之人似乎会忆起被尘封的过去...</content>
-	<content contentuid="hb258be75g3f36g47eega17ege37bb46a7b7a" Source="BOOK_BOO_BookOfOrigins">起源之书</content>
+	<content contentuid="hb258be75g3f36g47eega17ege37bb46a7b7a" Source="BOOK_BOO_BookOfOrigins">《起源之书》</content>
 	<content contentuid="h2588ce8bgd9abg4a99ga06fga29cc4ccd53c" Source="BOOK_BOO_BookOfOrigins">阅读</content>
 	<content contentuid="he269210dg8d16g4f1dg93e4g82940cfd66a9" Source="Summon_DisplayName.lsb" Key="Summon_SoulWolf_DisplayName">召唤灵狼</content>
 </contentList>

--- a/Mods/BookOfOrigins_395a6fbb-f855-4cb0-97a9-6674bfd1799b/Localization/Chinesetraditional/Chinesetraditional.xml
+++ b/Mods/BookOfOrigins_395a6fbb-f855-4cb0-97a9-6674bfd1799b/Localization/Chinesetraditional/Chinesetraditional.xml
@@ -17,7 +17,7 @@
 	<content contentuid="h69bc41c7ga800g4d1fgb20bg23ba44d44b64" Source="BOO_BookOfOrigins_Dialog.lsj">矮人之血脈。 &lt;i&gt;(石化之觸)&lt;/i&gt;</content>
 	<content contentuid="h59d3c53egb9e0g4fbcgb908ge936f1adbc54" Source="BOO_BookOfOrigins_Dialog.lsj">無法被束縛之人。 &lt;i&gt;(打破枷鎖)&lt;/i&gt;</content>
 	<content contentuid="h0380055dg8534g46ecga09fgbe08c34aaff7" Source="BOOK_BOO_BookOfOrigins">一本神秘的書籍。 能閱讀它之人似乎會憶起被塵封的過去...</content>
-	<content contentuid="hb258be75g3f36g47eega17ege37bb46a7b7a" Source="BOOK_BOO_BookOfOrigins">起源之書</content>
+	<content contentuid="hb258be75g3f36g47eega17ege37bb46a7b7a" Source="BOOK_BOO_BookOfOrigins">《起源之書》</content>
 	<content contentuid="h2588ce8bgd9abg4a99ga06fga29cc4ccd53c" Source="BOOK_BOO_BookOfOrigins">閱讀</content>
 	<content contentuid="he269210dg8d16g4f1dg93e4g82940cfd66a9" Source="Summon_DisplayName.lsb" Key="Summon_SoulWolf_DisplayName">召喚靈狼</content>
 </contentList>


### PR DESCRIPTION
When translating Automatic-Item-Levelling, I realized that in Chinese, we have the habit of adding 《》 symbols before and after the title of the book, but not in English, so I updated the Chinese translation again.