### PR TITLE
Create BRPortuguese.xml

### DIFF
--- a/Mods/BookOfOrigins_395a6fbb-f855-4cb0-97a9-6674bfd1799b/Localization/BRPortuguese/BRPortuguese.xml
+++ b/Mods/BookOfOrigins_395a6fbb-f855-4cb0-97a9-6674bfd1799b/Localization/BRPortuguese/BRPortuguese.xml
@@ -1,0 +1,35 @@
+<contentList>
+	<content contentuid="h260fdb55g52f3g40cbg8784g82be116bd64c" Source="BOO_BookOfOrigins_Dialog.lsj">Você relembra sua descendência. Você tem uma...</content>
+	<content contentuid="he4237418g0591g4fe3ga5b3gc3f43c2349b5" Source="BOO_BookOfOrigins_Dialog.lsj">Persuadindo aqueles ao seu redor. &lt;i&gt;(Canção Mágica)&lt;/i&gt;</content>
+	<content contentuid="h46c8c094g4917g44b2ga505g7252c4be5487" Source="BOO_BookOfOrigins_Dialog.lsj">Hmm. Você parece ter esquecido sua linhagem.</content>
+	<content contentuid="h6d6ba4f0gbaecg4dc2g8c0ag296892624e8a" Source="BOO_BookOfOrigins_Dialog.lsj">Você repentinamente lembra suas origens. Você era...</content>
+	<content contentuid="h198680a3gebf0g470fgbd7dg091b1ed916f4" Source="BOO_BookOfOrigins_Dialog.lsj">Avistando uma barganha. &lt;i&gt;(Econômico)&lt;/i&gt;</content>
+	<content contentuid="h2d99979bgab25g414bg9f2cg9cb3cb57d1e4" Source="BOO_BookOfOrigins_Dialog.lsj">Descendência Humana. &lt;i&gt;(Encorajar)&lt;/i&gt;</content>
+	<content contentuid="hf79ce5f5gb5c6g40d7gbed5g6eb80dd87957" Source="BOO_BookOfOrigins_Dialog.lsj">Recuperando memórias da carne. &lt;i&gt;(Devorador de Cadáver)&lt;/i&gt;</content>
+	<content contentuid="hbd76d0bfg5669g4d09g802cgaba0b159e063" Source="BOO_BookOfOrigins_Dialog.lsj">Descendência dos Lagartos.&lt;i&gt; (Chama do Dragão)&lt;/i&gt;</content>
+	<content contentuid="h397a567dgcfc6g436egb674gcf47e1577bea" Source="BOO_BookOfOrigins_Dialog.lsj">Você era adepto em...</content>
+	<content contentuid="h4aa937f3g5c25g4844g9805g11a9c69e7e19" Source="BOO_BookOfOrigins_Dialog.lsj">Hmm. Você se esqueceu.</content>
+	<content contentuid="hcbf794f0g8b24g4b9eg84ccgec63997e03f0" Source="BOO_BookOfOrigins_Dialog.lsj">Um mestre de manipular o tempo. &lt;i&gt;(Salto Temporal)&lt;/i&gt;</content>
+	<content contentuid="hde23477dg6beeg4555ga216g4cec678e35fe" Source="BOO_BookOfOrigins_Dialog.lsj">Um mestre de um grande lobo. &lt;i&gt;(Invocar Alma de Lobo)&lt;/i&gt;</content>
+	<content contentuid="h6c023c14gac2fg4320gb7c5g2828cd67da55" Source="BOO_BookOfOrigins_Dialog.lsj">Um bardo com a voz de um demônio. &lt;i&gt;(Canção da Loucura)&lt;/i&gt;</content>
+	<content contentuid="h6005678cg5e13g40eag8585g0106c9400661" Source="BOO_BookOfOrigins_Dialog.lsj">Alguém com os olhos penetrantes de um demônio. &lt;i&gt;(Encarada Demoníaca)&lt;/i&gt;</content>
+	<content contentuid="hdd5dd74agb372g4d32g9276gf605c9f4d16d" Source="BOO_BookOfOrigins_Dialog.lsj">Descendência Élfica. &lt;i&gt;(Sacrifício da Carne)&lt;/i&gt;</content>
+	<content contentuid="hffe697e4g9b02g45c0g8732gf92489e05976" Source="BOO_BookOfOrigins_Dialog.lsj">Descendência Estranha. &lt;i&gt;(Fingir-se de Morto)&lt;/i&gt;</content>
+	<content contentuid="h6fb42bd8g0c41g4c6fgad4fgdca594d4527a" Source="BOO_BookOfOrigins_Dialog.lsj">Lembrando sabedorias antigas.&lt;i&gt; (Conhecimento Ancestral)&lt;/i&gt;</content>
+	<content contentuid="hfaa24153gd187g488dga56dg8b5c5aa2d51f" Source="BOO_BookOfOrigins_Dialog.lsj">Esgueirando-se &lt;i&gt;(Malícia Anã)&lt;/i&gt;</content>
+	<content contentuid="h5ab71b5cg25c1g4426ga953g91584d64120d" Source="BOO_BookOfOrigins_Dialog.lsj">Suas origens e linhagem, se solidificam novamente em sua mente.</content>
+	<content contentuid="h53229adbg0b88g4890g8bdega3050787337b" Source="BOO_BookOfOrigins_Dialog.lsj">Uma grande presença na tempestade. &lt;i&gt;(Tempestade Cegante)&lt;/i&gt;</content>
+	<content contentuid="h5e9ca7e6g8e79g470fg9fb0g48c9282a1ca4" Source="BOO_BookOfOrigins_Dialog.lsj">Atingindo alvos em suas fraquesas. &lt;i&gt;(Engenhoso)&lt;/i&gt;</content>
+	<content contentuid="h02a2d549ge626g4fc9g8290g20318d145a6c" Source="BOO_BookOfOrigins_Dialog.lsj">Hmm. Na verdade, você esqueceu suas origens.</content>
+	<content contentuid="h121b9919g0641g40c4g87cag6063dfec781b" Source="BOO_BookOfOrigins_Dialog.lsj">Levando uma surra. &lt;i&gt;(Robusto)&lt;/i&gt;</content>
+	<content contentuid="hd92c9993ge50ag4e70gb818gdf0e4d6d1027" Source="BOO_BookOfOrigins_Dialog.lsj">Seu talento inato incluía...</content>
+	<content contentuid="hce89b3a5g9743g4180ga810gc7430cd9f290" Source="BOO_BookOfOrigins_Dialog.lsj">Hmm. Você não consegue lembrar.</content>
+	<content contentuid="hbac57b62g4807g4666g98cag83565fc7fec3" Source="BOO_BookOfOrigins_Dialog.lsj">Afastando-se de certos elementos. &lt;i&gt;(Sofisticado)&lt;/i&gt;</content>
+	<content contentuid="hb04fdbf3g44c1g407cga293g428693905000" Source="BOO_BookOfOrigins_Dialog.lsj">Um defensor dos fracos. &lt;i&gt;(Domo de Proteção)&lt;/i&gt;</content>
+	<content contentuid="h69bc41c7ga800g4d1fgb20bg23ba44d44b64" Source="BOO_BookOfOrigins_Dialog.lsj">Descendência de Anões. &lt;i&gt;(Toque Petrificante)&lt;/i&gt;</content>
+	<content contentuid="h59d3c53egb9e0g4fbcgb908ge936f1adbc54" Source="BOO_BookOfOrigins_Dialog.lsj">Alguém que não poderia ser acorrentado. &lt;i&gt;(Romper os Grilhões)&lt;/i&gt;</content>
+	<content contentuid="h0380055dg8534g46ecga09fgbe08c34aaff7" Source="BOOK_BOO_BookOfOrigins">Um tomo com propriedades místicas. Aqueles que o lerem, parecem se lembrar de seu passado vividamente.</content>
+	<content contentuid="hb258be75g3f36g47eega17ege37bb46a7b7a" Source="BOOK_BOO_BookOfOrigins">Livro das Origens</content>
+	<content contentuid="h2588ce8bgd9abg4a99ga06fga29cc4ccd53c" Source="BOOK_BOO_BookOfOrigins">Ler</content>
+	<content contentuid="he269210dg8d16g4f1dg93e4g82940cfd66a9" Source="Summon_DisplayName.lsb" Key="Summon_SoulWolf_DisplayName">Invocar Alma de Lobo</content>
+</contentList>


### PR DESCRIPTION
Brazilian Portuguese translation.

Based of original game translation, but adapted to the mod context (wolf skill name and choices context).
Not sure if "BRPortuguese" would be the best "tag name", but it's understandable for portuguese speakers, since the usual is "PT/BR" for brazilian portuguese and "PT/PT" for portuguese of portugal. But i avoided slashes for folders sake.